### PR TITLE
Ignore empty tables when loading FIA

### DIFF
--- a/R/functionsFIA.R
+++ b/R/functionsFIA.R
@@ -627,7 +627,6 @@ readFHM <- function(dir, tables = NULL, nCores = 1){
   uniqueNames <- unique(names(inTables))
   ## Works regardless of whether or not there are duplicate names (multiple states)
   for (i in 1:length(uniqueNames)){
-    cat(uniqueNames[i])
     outTables[[uniqueNames[i]]] <- rbindlist(inTables[names(inTables) == uniqueNames[i]], fill=TRUE)
   }
 

--- a/R/functionsFIA.R
+++ b/R/functionsFIA.R
@@ -627,6 +627,7 @@ readFHM <- function(dir, tables = NULL, nCores = 1){
   uniqueNames <- unique(names(inTables))
   ## Works regardless of whether or not there are duplicate names (multiple states)
   for (i in 1:length(uniqueNames)){
+    cat(uniqueNames[i])
     outTables[[uniqueNames[i]]] <- rbindlist(inTables[names(inTables) == uniqueNames[i]], fill=TRUE)
   }
 
@@ -884,9 +885,11 @@ readFIA <- function(dir,
       #file <- as.data.frame(file)
       fileName <- str_sub(files[n], 1, -5)
 
-      inTables[[fileName]] <- file
+      # Skip over files that are empty
+      if(nrow(file) > 0){
+        inTables[[fileName]] <- file
+      }
     }
-
 
     # Give them some names
     #names(inTables) <- files


### PR DESCRIPTION
The following code fails:
```r
library(rFIA)
db <- getFIA(states = c('NH','VT','ME', 'NY'), dir = 'data', common = TRUE)
fiaNE <- readFIA('data', common = FALSE, states = c('ME', 'NY','VT', 'NH'))
tpaNE <- tpa(fiaNE)
```
The problem occurs because some CSV files are empty. In this case, it is one of the  VT files. The updated code skips over empty data.tables when loading them all to the list.