### PR TITLE
Update CARB_TOTAL_VAR

### DIFF
--- a/R/carbon.R
+++ b/R/carbon.R
@@ -396,7 +396,7 @@ carbon <- function(db,
                CARB_TOTAL_SE = sqrt(caVar) / CARB_TOTAL *100,
                ## Var total
                AREA_TOTAL_VAR = aVar,
-               CARB_TOTAL_VAR = caVar,
+               CARB_TOTAL_VAR = cVar,
                ## nPlots
                nPlots_TREE = plotIn_TREE,
                nPlots_AREA = plotIn_AREA)


### PR DESCRIPTION
This change addresses Issue #13. Rather than surfacing `CARB_TOTAL_VAR` when both `totals` and `variance` flags are set to true, the `carbon` function was instead reporting back `CAR_ACRE_VAR`.