### PR TITLE
fixes download link for zipped CSV files

### DIFF
--- a/R/readWriteGet.R
+++ b/R/readWriteGet.R
@@ -433,7 +433,7 @@ Did you accidentally include the state abbreviation in front of the table name? 
       # Temporary directory to download to
       temp <- paste0(tempDir, '/', states[i],'.zip') #tempfile()
       ## Make the URL
-      url <- paste0('https://apps.fs.usda.gov/fia/datamart/CSV/', states[i],'.zip')
+      url <- paste0('https://apps.fs.usda.gov/fia/datamart/CSV/', states[i],'_CSV.zip')
       #newName <- paste0(str_sub(url, 1, -4), 'csv')
       ## Download as temporary file
       download.file(url, temp, timeout = 3600)


### PR DESCRIPTION
Hey @hunter-stanke!

It looks like FIA changed the links to the zipped CSV files ever so slightly in their latest push to FIADB. This pull request changes the address for downloading the CSV files in `rFIA::getFIA`. 